### PR TITLE
hotfix/ApiDefaultSerialization

### DIFF
--- a/src/Innovt.AspNetCore/ApiStartupBase.cs
+++ b/src/Innovt.AspNetCore/ApiStartupBase.cs
@@ -88,7 +88,7 @@ public abstract class ApiStartupBase
     /// <summary>
     ///     If true will set default Json Options(JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase) etc
     /// </summary>
-    public bool SetDefaultJsonOptions { get; set; }
+    public bool SetDefaultJsonOptions { get; set; } = true;
 
     /// <summary>
     ///     Gets the configuration for the application.


### PR DESCRIPTION
Você criou um campo pra dizer se deve ou não usar o comportamento padrão, e inicia como "false" por ser um campo que indica se quero ou não manter comportamento padrão da API, ele deveria já iniciar "true"

Percebi ao atualizar da versão 6.x para versão 8.x

A resposta da API na versão 6.x retornava em CamelCase
```
{
    "isNumberPagination": true,
[..]
```

E passou a retornar em PascalCase
```
{
    "IsNumberPagination": true,
[..]
```

O ideal é manter o mesmo comportamento para não ter impacto em antigos consumidores do Framework