### PR TITLE
hotfix/DomainEventEmpty

### DIFF
--- a/src/Innovt.Cloud.AWS.Kinesis/DataProducer.cs
+++ b/src/Innovt.Cloud.AWS.Kinesis/DataProducer.cs
@@ -5,6 +5,7 @@
 using Amazon.Kinesis;
 using Amazon.Kinesis.Model;
 using Innovt.Cloud.AWS.Configuration;
+using Innovt.Core.Collections;
 using Innovt.Core.CrossCutting.Log;
 using Innovt.Core.Utilities;
 using Innovt.Domain.Core.Streams;
@@ -77,7 +78,7 @@ public class DataProducer<T> : AwsBaseService where T : class, IDataStream
     /// <returns>A list of <see cref="PutRecordsRequestEntry" /> representing the data streams.</returns>
     private static List<PutRecordsRequestEntry> CreatePutRecords(IList<T> dataStreams, Activity activity)
     {
-        if (dataStreams == null || !dataStreams.Any())
+        if (dataStreams.IsNullOrEmpty())
             return null;
 
         var request = new List<PutRecordsRequestEntry>();
@@ -112,7 +113,7 @@ public class DataProducer<T> : AwsBaseService where T : class, IDataStream
     {
         Logger.Info("Kinesis Publisher Started");
 
-        if (dataList is null || !dataList.Any())
+        if (dataList.IsNullOrEmpty())
         {
             Logger.Info("The event list is empty or null.");
             return;

--- a/src/Innovt.Cloud.AWS.Kinesis/DataProducer.cs
+++ b/src/Innovt.Cloud.AWS.Kinesis/DataProducer.cs
@@ -2,6 +2,12 @@
 // Author: Michel Borges
 // Project: Innovt.Cloud.AWS.Kinesis
 
+using Amazon.Kinesis;
+using Amazon.Kinesis.Model;
+using Innovt.Cloud.AWS.Configuration;
+using Innovt.Core.CrossCutting.Log;
+using Innovt.Core.Utilities;
+using Innovt.Domain.Core.Streams;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,12 +17,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Kinesis;
-using Amazon.Kinesis.Model;
-using Innovt.Cloud.AWS.Configuration;
-using Innovt.Core.CrossCutting.Log;
-using Innovt.Core.Utilities;
-using Innovt.Domain.Core.Streams;
 
 namespace Innovt.Cloud.AWS.Kinesis;
 
@@ -77,7 +77,7 @@ public class DataProducer<T> : AwsBaseService where T : class, IDataStream
     /// <returns>A list of <see cref="PutRecordsRequestEntry" /> representing the data streams.</returns>
     private static List<PutRecordsRequestEntry> CreatePutRecords(IList<T> dataStreams, Activity activity)
     {
-        if (dataStreams == null)
+        if (dataStreams == null || !dataStreams.Any())
             return null;
 
         var request = new List<PutRecordsRequestEntry>();
@@ -112,7 +112,7 @@ public class DataProducer<T> : AwsBaseService where T : class, IDataStream
     {
         Logger.Info("Kinesis Publisher Started");
 
-        if (dataList is null)
+        if (dataList is null || !dataList.Any())
         {
             Logger.Info("The event list is empty or null.");
             return;


### PR DESCRIPTION
Devido a sua alteração de commit ca5bffe1283a96770baceac9339ce88069cdff29, você fez o Entity iniciar com uma lista vazia e ao tentar publicar os eventos com essa lista vazia ocorre um erro no SDK da AWS