### PR TITLE
hotfix/EntityNewProperty

### DIFF
--- a/src/Innovt.Domain.Core/Model/Entity.cs
+++ b/src/Innovt.Domain.Core/Model/Entity.cs
@@ -2,17 +2,17 @@
 // Author: Michel Borges
 // Project: Innovt.Domain.Core
 
+using Innovt.Domain.Core.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Innovt.Domain.Core.Events;
 
 namespace Innovt.Domain.Core.Model;
 
 /// <summary>
 ///     Represents an abstract base class for entities in the domain model.
 /// </summary>
-public abstract class Entity
+public abstract class Entity<T> where T : struct
 {
     private readonly List<DomainEvent> domainEvents;
 
@@ -29,7 +29,7 @@ public abstract class Entity
     ///     Initializes a new instance of the <see cref="Entity" /> class with a specific identifier.
     /// </summary>
     /// <param name="id">The identifier for the entity.</param>
-    protected Entity(int id):this()
+    protected Entity(T id) : this()
     {
         Id = id;
     }
@@ -37,7 +37,7 @@ public abstract class Entity
     /// <summary>
     ///     Gets or sets the unique identifier for the entity.
     /// </summary>
-    public virtual int Id { get; set; }
+    public T Id { get; set; }
 
     /// <summary>
     ///     Gets or sets the date and time when the entity was created.
@@ -50,28 +50,27 @@ public abstract class Entity
     /// <returns><c>true</c> if the entity is new; otherwise, <c>false</c>.</returns>
     public bool IsNew()
     {
-        return Id == 0;
+        return Id.Equals(default(T));
     }
 
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return Id;
+        return HashCode.Combine(Id);
     }
 
     /// <inheritdoc />
     public override bool Equals(object obj)
     {
-        var anotherEntity = obj as Entity;
-
-        return anotherEntity?.Id == Id;
+        return obj is Entity<T> entity &&
+               EqualityComparer<T>.Default.Equals(Id, entity.Id);
     }
 
     /// <summary>
     ///     Adds a domain event to the entity.
     /// </summary>
     /// <param name="domainEvent">The domain event to add.</param>
-    public Entity AddDomainEvent(DomainEvent domainEvent)
+    public Entity<T> AddDomainEvent(DomainEvent domainEvent)
     {
         if (domainEvent == null) throw new ArgumentNullException(nameof(domainEvent));
 
@@ -95,7 +94,6 @@ public abstract class Entity
 ///     Represents an abstract base class for entities in the domain model with a specific type for the identifier.
 /// </summary>
 /// <typeparam name="T">The type of the identifier.</typeparam>
-public abstract class Entity<T> : Entity where T : struct
+public abstract class Entity : Entity<int>
 {
-    public new T Id { get; set; }
 }

--- a/src/Innovt.Domain.Core/Model/ValueObject.cs
+++ b/src/Innovt.Domain.Core/Model/ValueObject.cs
@@ -2,17 +2,20 @@
 // Author: Michel Borges
 // Project: Innovt.Domain.Core
 
+using System;
+using System.Collections.Generic;
+
 namespace Innovt.Domain.Core.Model;
 
 /// <summary>
 ///     Represents a base class for value objects.
 /// </summary>
-public abstract class ValueObject
+public abstract class ValueObject<T> where T : struct
 {
     /// <summary>
     ///     Gets or sets the identifier for the value object.
     /// </summary>
-    public virtual int Id { get; set; }
+    public T Id { get; set; }
 
     /// <summary>
     ///     Determines whether the current value object is equal to another object.
@@ -24,7 +27,8 @@ public abstract class ValueObject
         if (ReferenceEquals(this, obj)) return true;
         if (obj is null) return false;
 
-        return (obj as ValueObject)?.Id == Id;
+        return obj is ValueObject<T> @object &&
+            EqualityComparer<T>.Default.Equals(Id, @object.Id);
     }
 
     /// <summary>
@@ -33,7 +37,7 @@ public abstract class ValueObject
     /// <returns>A hash code for the current value object.</returns>
     public override int GetHashCode()
     {
-        return base.GetHashCode();
+        return HashCode.Combine(Id);
     }
 }
 
@@ -41,10 +45,6 @@ public abstract class ValueObject
 ///     Represents a base class for value objects with a generic identifier type.
 /// </summary>
 /// <typeparam name="T">The type of the identifier.</typeparam>
-public abstract class ValueObject<T> : ValueObject where T : struct
+public abstract class ValueObject : ValueObject<int>
 {
-    /// <summary>
-    ///     Gets or sets the identifier for the value object.
-    /// </summary>
-    public new T Id { get; set; }
 }


### PR DESCRIPTION
Para algumas situações de reflection e para o SDK do DynamoDB, o força o novo tipo da propriedade da classe base gera uma duplicação dela, ao tentar trazer alguns desse campos para dicionário ocorre um exceção de duplicação 

Exemplo:
![image](https://github.com/Innovtt/Innovt.Platform/assets/7155838/e2956534-4fcc-4f58-9c4a-830201cf7728)

Nessa situação pode ocorrer um InvalidException
```
System.InvalidOperationException: Dictionary already contains item with key Id\n   at 
Amazon.Util.Internal.InternalSDKUtils.AddToDictionary[TKey,TValue](Dictionary`2 dictionary, TKey key, TValue value)\n   at 
Amazon.DynamoDBv2.DataModel.StorageConfig.GetMembersDictionary(Type type)\n   at 
Amazon.DynamoDBv2.DataModel.StorageConfig..ctor(Type targetType)\n   at 
Amazon.DynamoDBv2.DataModel.ItemStorageConfig..ctor(Type targetType)\n   at
```
